### PR TITLE
Remove stale non-authored file references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -38,12 +38,7 @@ You can redistribute it and/or modify it under either the terms of the GPL
        d) make other distribution arrangements with the author.
 
   4. You may modify and include the part of the software into any other
-     software (possibly commercial).  But some files in the distribution
-     are not written by the author, so that they are not under this terms.
-
-     They are gc.c(partly), utils.c(partly), regex.[ch], st.[ch] and some
-     files under the ./missing directory.  See each file for the copying
-     condition.
+     software (possibly commercial). 
 
   5. The scripts and library files supplied as input to or produced as 
      output from the software do not automatically fall under the


### PR DESCRIPTION
The LICENSE file at item 4 contained references to files not written by the author. Presumably they were accidentally copied from somewhere when installing the license in 42a51b7a95201d254e62c53322e9093cd3ce397e.

Since none of the mentioned files exists in this repository, I removed the references.